### PR TITLE
Added unit test for run_DomainAnnotation_Sets

### DIFF
--- a/test/kb_phylogenomics_server_test.py
+++ b/test/kb_phylogenomics_server_test.py
@@ -83,3 +83,52 @@ class kb_phylogenomicsTest(unittest.TestCase):
         # Check returned data with
         # self.assertEqual(ret[...], ...) or other unittest methods
         pass
+
+
+    ### Annotate domains in a GenomeSet
+    def test_annotateDomains(self):
+
+        # make a simple GenomeSet that refers to two public Genomes
+        # kb|g.371 is Shewanella MR-1
+        # kb|g.3562 is DvH
+        testGS = {
+            'description': 'two genomes',
+            'elements': {
+                'so': {
+                    'ref': '4258/35060/1'
+                },
+                'dvh': {
+                    'ref': '4258/34734/1'
+                }
+            }
+        }
+
+        obj_info = self.getWsClient().save_objects({'workspace': self.getWsName(),       
+                                                    'objects': [
+                                                        {
+                                                            'type':'KBaseSearch.GenomeSet',
+                                                            'data':testGS,
+                                                            'name':'test_genomeset',
+                                                            'meta':{},
+                                                            'provenance':[
+                                                                {
+                                                                    'service':'kb_phylogenomics',
+                                                                    'method':'test_annotateDomains'
+                                                                }
+                                                            ]
+                                                        }]
+                                                })
+
+        pprint(obj_info)
+
+        # run annotateDomains
+        params = {
+            'workspace_name': self.getWsName(),
+            'input_genomeSet_ref': str(obj_info[0][6])+'/'+str(obj_info[0][0]),
+            'override_annot': 0
+        }
+
+        result = self.getImpl().run_DomainAnnotation_Sets(self.getContext(),params)
+        print('RESULT:')
+        pprint(result)
+


### PR DESCRIPTION
This unit test reproduces this bug reported to JMC by Dylan:

ServerError: JSONRPCError: -32500. Must provide one and only one of workspace name (was: null) or id (was: null)

I still don't know how to fix it, but at least we have a unit test now!