### PR TITLE
DEVOPS-2382 Fix missing cog.aux

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -15,6 +15,7 @@ jobs:
         run: |
           mkdir -p $(pwd)/bin
           docker run ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 genscript > $(pwd)/bin/kb-sdk
+          docker tag ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 kbase/kb-sdk:latest
           chmod 755 $(pwd)/bin/kb-sdk
           echo "$(pwd)/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -19,10 +19,13 @@ jobs:
           chmod 755 $(pwd)/bin/kb-sdk
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
-      - name: Setup and run KBase SDK Tests
+      - name: Setup KBase SDK Tests
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
           kb-sdk test || true
           sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
+        continue-on-error: true
+
+      - name: Run KBase SDK Tests
           kb-sdk test

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -11,18 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup kb-sdk
+      - name: Download kb-sdk and set up path
         run: |
           mkdir -p $(pwd)/bin
           docker run ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 genscript > $(pwd)/bin/kb-sdk
           chmod 755 $(pwd)/bin/kb-sdk
           echo "$(pwd)/bin" >> $GITHUB_PATH
 
-      - name: Setup test config
+      - name: Setup and run KBase SDK Tests
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
-          sed -i "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
-
-      - name: Run tests
-        run: kb-sdk test
+          kb-sdk test || true
+          sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
+          kb-sdk test

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -24,7 +24,6 @@ jobs:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
           kb-sdk test || true
-          mkdir -p ./test_local
           sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
         continue-on-error: true
 

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -24,8 +24,9 @@ jobs:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
           kb-sdk test || true
+          mkdir -p ./test_local
           sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
         continue-on-error: true
 
       - name: Run KBase SDK Tests
-          kb-sdk test
+        run: kb-sdk test

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -1,63 +1,28 @@
-name: KBase SDK Tests
+name: KBase SDK Test
 
 on:
   push:
-    branches:
-    - master
-    - main
   pull_request:
-    branches:
-    - master
-    - main
-    - develop
-  workflow_dispatch:
 
 jobs:
-
-  sdk_tests:
+  test:
     runs-on: ubuntu-latest
+
     steps:
+      - uses: actions/checkout@v4
 
-    - name: Check out GitHub repo
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      uses: actions/checkout@v2
+      - name: Setup kb-sdk
+        run: |
+          mkdir -p $(pwd)/bin
+          docker run ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 genscript > $(pwd)/bin/kb-sdk
+          chmod 755 $(pwd)/bin/kb-sdk
+          echo "$(pwd)/bin" >> $GITHUB_PATH
 
-    - name: Check out Actions CI files
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      uses: actions/checkout@v2
-      with:
-        repository: 'kbaseapps/kb_sdk_actions'
-        path: 'kb_sdk_actions'
+      - name: Setup test config
+        env:
+          KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
+        run: |
+          sed -i "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
 
-
-    - name: Set up test environment
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      shell: bash
-      env:
-        KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-      run: |
-        # Verify kb_sdk_actions clone worked
-        test -f "$HOME/kb_sdk_actions/bin/kb-sdk" && echo "CI files cloned"
-        # Pull kb-sdk & create startup script
-        docker pull kbase/kb-sdk
-       
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/make_testdir && echo "Created test_local"
-        test -f "test_local/test.cfg" && echo "Confirmed config exists"
-
-    - name: Configure authentication
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      shell: bash
-      env:
-        KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
-      run: |
-        # Add token to config
-        sed -ie "s/^test_token=.*$/&$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
-
-    - name: Run tests
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
-        bash <(curl -s https://codecov.io/bash)
+      - name: Run tests
+        run: kb-sdk test

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -11,19 +11,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download kb-sdk and set up path
+      - name: Download kb-sdk, set up path, and modify script
         run: |
           mkdir -p $(pwd)/bin
           docker run ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 genscript > $(pwd)/bin/kb-sdk
           docker tag ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 kbase/kb-sdk:latest
           chmod 755 $(pwd)/bin/kb-sdk
           echo "$(pwd)/bin" >> $GITHUB_PATH
+          sed -i 's/docker run -it/docker run /g' $(pwd)/bin/kb-sdk
 
       - name: Setup KBase SDK Tests
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |
           kb-sdk test || true
+          mkdir -p ./test_local
           sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
         continue-on-error: true
 

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -1,4 +1,4 @@
-name: KBase SDK Test
+name: Run KBase SDK Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download kb-sdk, set up path, and modify script
+      - name: Download kb-sdk, set up path, and modify kb-sdk helper script
         run: |
           mkdir -p $(pwd)/bin
           docker run ghcr.io/kbase/kb_sdk_patch-develop:br-0.0.4 genscript > $(pwd)/bin/kb-sdk
@@ -20,7 +20,7 @@ jobs:
           echo "$(pwd)/bin" >> $GITHUB_PATH
           sed -i 's/docker run -it/docker run /g' $(pwd)/bin/kb-sdk
 
-      - name: Setup KBase SDK Tests
+      - name: Setup KBase SDK Tests and inject kbase token
         env:
           KBASE_TEST_TOKEN: ${{ secrets.KBASE_TEST_TOKEN }}
         run: |

--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           kb-sdk test || true
           mkdir -p ./test_local
-          sed "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test/test.cfg.example > ./test_local/test.cfg
+          sed -i "s/^test_token=.*$/test_token=$KBASE_TEST_TOKEN/g" ./test_local/test.cfg
         continue-on-error: true
 
       - name: Run KBase SDK Tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### Version 1.9.1
+* Updated version to sync with [DomainAnnotation](https://github.com/kbaseapps/DomainAnnotation/blob/093b943ead242d24227978d1df0b713d067beb89/ui/narrative/methods/annotate_domains_in_a_genome/spec.json#L30-L65) to fix `Server error: /data/db/Cog.aux (Read-only file system)`
+
 ### Version 1.9.0
 __Changes__
 - added Score_Orthologs_Evolutionary_Rates() App

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.9.0
+    1.9.1
 
 owners:
     [dylan,jmc]

--- a/lib/kb_phylogenomics/kb_phylogenomicsImpl.py
+++ b/lib/kb_phylogenomics/kb_phylogenomicsImpl.py
@@ -3461,7 +3461,7 @@ This module contains methods for running and visualizing results of phylogenomic
             domains_obj_name += '.DomainAnnotation'
             domains_obj_name = 'domains_' + domains_obj_name  # DEBUG
             DomainAnnotation_Params = {'genome_ref': genome_ref,
-                                       'dms_ref': 'KBasePublicGeneDomains/All-1.0.8', # for Pfam 32
+                                       'dms_ref': 'KBasePublicGeneDomains/All-1.0.10', # for Pfam 32
                                        'ws': params['workspace_name'],
                                        #'ws': ws_name_by_genome_ref[genome_ref],
                                        'output_result_id': domains_obj_name


### PR DESCRIPTION
The params that the KBPArallel gets are failing with a missing cog.aux file

```
                 'job_input': {'app_id': 'DomainAnnotation',
                               'method': 'DomainAnnotation.search_domains',
                               'narrative_cell_info': {},
                               'params': [{'dms_ref': 'KBasePublicGeneDomains/All-1.0.8',
```

When you make a cell for DomainAnnotation you can see
```
        "dms_ref": "KBasePublicGeneDomains/All-1.0.10",
```